### PR TITLE
feat(git): bucket review-pr-comments by severity with LOW auto-reject, bump to v1.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "stepwise-git",
       "source": "./git",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "description": "Git and GitHub workflow: semantic commits and rigorous PR comment review",
       "keywords": ["git", "commit", "pr", "code-review", "github", "version-control"]
     },

--- a/git/.claude-plugin/plugin.json
+++ b/git/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stepwise-git",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Git and GitHub workflow: semantic commits and rigorous PR comment review",
   "author": {
     "name": "Jorge Castro",

--- a/git/skills/review-pr-comments/SKILL.md
+++ b/git/skills/review-pr-comments/SKILL.md
@@ -17,7 +17,11 @@ Review all open PR comments, present a summary with your position on each, itera
 - **Scope**: only active comments (both inline and general). Ignore resolved and outdated ones.
 - **Bias**: defend the existing code. Only accept a change with a concrete technical reason (bug, violated principle, demonstrable readability gain). Reject style preferences without objective justification.
 - **Context**: before evaluating, read the full files affected plus related files (tests, types, direct dependencies).
-- **Summary format**: after reviewing every comment, present all decisions together, one compact block per comment. Do NOT quote the full body verbatim — the user has GitHub open and can click through. Rephrase the claim in one sentence in your own words. Format:
+- **Summary format**: after reviewing every comment, present all decisions grouped by severity, one compact block per comment. Do NOT quote the full body verbatim — the user has GitHub open and can click through. Rephrase the claim in one sentence in your own words.
+
+  Extract severity from the comment's prefix when present (`[SECURITY — CRITICAL]`, `[CODE QUALITY — HIGH]`, `[TESTS — LOW]`, `[SUGGESTION]`, etc.). If no prefix, infer: correctness/security bugs → HIGH; performance, tests, or missing error paths → MEDIUM; style, docstrings, naming, "for symmetry", "for consistency" nits → LOW.
+
+  Block format per comment:
 
   ```
   N. [ACCEPT|REJECT] {path}:{line or "general"} @{user} — {your one-sentence rephrase of the claim}
@@ -27,7 +31,22 @@ Review all open PR comments, present a summary with your position on each, itera
      Link: {comment.html_url}
   ```
 
-  Then ask: "Do you agree with these positions?"
+  Present them in this order:
+
+  ```
+  HIGH — decision required:
+    <blocks>
+
+  MEDIUM — decision required:
+    <blocks>
+
+  LOW / nits — proposed REJECT in batch (unless you rescue any):
+    <blocks, but with just the one-line rephrase + link; no Reason/Alternative>
+  ```
+
+  Then ask ONE question: **"Confirm my ACCEPT/REJECT on HIGH+MEDIUM and I discard the LOW batch — or do you want to rescue any LOW?"**
+
+  Omit a section entirely if it has no comments. If ALL comments are LOW and every one would be REJECT, offer: "This round is all low-severity nits and rehashes of earlier positions. Close the round without replying?" — closing without a reply is a valid outcome when the original threads already carry your positions.
 
   Exception: if a comment is genuinely short (<3 lines) and self-contained, quoting it verbatim is fine. The rule is "don't repeat information the user can read in one glance in GitHub".
 


### PR DESCRIPTION
## Summary

Groups the `review-pr-comments` summary by severity, collapses LOW nits into
a single batch REJECT, and asks the user one question instead of N.

- Extracts severity from `[SECURITY — CRITICAL]` / `[CODE QUALITY — HIGH]` /
  `[TESTS — LOW]` / `[SUGGESTION]` prefixes; infers when missing.
- Names LOW explicitly (style, docstrings, "for symmetry", "for consistency"
  nits) so the model does not over-elevate them into MEDIUM.
- Adds a "close without replying" escape when the round is entirely LOW
  rehashes — the original threads already carry the author's positions.
- Bumps `stepwise-git` to `v1.5.0` (`marketplace.json` + `plugin.json`,
  matching the v1.4.0 pattern).

## Why

Reviewing a 15-comment PR round (control-panel-api#1031, mostly LOW nits and
rehashes) meant ~15 min of no-op individual decisions, most going the same
way ("REJECT — just-in-case anti-pattern", "REJECT — same position as prior
thread"). The old flat format did not distinguish "decision that changes
what I ship" from "nit I'm going to reject anyway".

Complements the reviewer-side change in
[Toni-Agent-Services/company#…](https://github.com/Toni-Agent-Services/company/pull/new/chore/claude-review-round-aware-severity-floor)
that stops the reviewer generating those LOW rounds in the first place.

## Test plan

- [ ] Run `/stepwise-git:review-pr-comments` on a PR with mixed HIGH/MEDIUM/LOW
      to confirm the three sections render correctly.
- [ ] Run on a round that is entirely LOW to confirm the "close without
      replying" prompt fires.
- [ ] Confirm the version bump is picked up when the plugin cache refreshes.